### PR TITLE
TypeError: 'PosixPath' object is not iterable

### DIFF
--- a/pyzelda/zelda.py
+++ b/pyzelda/zelda.py
@@ -102,7 +102,7 @@ class Sensor():
         config = ConfigParser.ConfigParser()
 
         try:
-            config.read(configfile)
+            config.read(str(configfile))
 
             # mask physical parameters
             self._Fratio = kwargs.get('mask_Fratio', float(config.get('mask', 'Fratio')))


### PR DESCRIPTION
On Python 3.5.3, I got an error 
TypeError: 'PosixPath' object is not iterable
After some reading, I found out here that this comes from differences between Python versions before and after 3.6 (https://realpython.com/python-pathlib/) 
To make your code backward compatible, I therefore suggest to change this line which solved the problem